### PR TITLE
FIXED: t/f was returning true all the time

### DIFF
--- a/frontend/public/scripts/createQuiz.js
+++ b/frontend/public/scripts/createQuiz.js
@@ -92,7 +92,7 @@ function addTfQuestion() {
                         <input type="text" id="optionText-${questionIndex}-1-f" name="questions[${questionIndex}][options][1][option_text]" value="False" required readonly>
                         
                         <label for="isCorrect-${questionIndex}-1-f">Is Correct:</label>
-                        <input type="radio" id="isCorrect-${questionIndex}-1-f" name="questions[${questionIndex}][options][0][is_correct]">
+                        <input type="radio" id="isCorrect-${questionIndex}-1-f" name="questions[${questionIndex}][options][1][is_correct]">
                     </div>
                 </div>
             `;


### PR DESCRIPTION
While creating true-false questions, the system always took true as a correct answer. An array declaration fault caused this problem in createQuiz.js L:96.